### PR TITLE
Support LogAppend timestamp

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -519,13 +519,17 @@ func (child *partitionConsumer) parseRecords(batch *RecordBatch) ([]*ConsumerMes
 		if offset < child.offset {
 			continue
 		}
+		timestamp := batch.FirstTimestamp.Add(rec.TimestampDelta)
+		if batch.LogAppendTime {
+			timestamp = batch.MaxTimestamp
+		}
 		messages = append(messages, &ConsumerMessage{
 			Topic:     child.topic,
 			Partition: child.partition,
 			Key:       rec.Key,
 			Value:     rec.Value,
 			Offset:    offset,
-			Timestamp: batch.FirstTimestamp.Add(rec.TimestampDelta),
+			Timestamp: timestamp,
 			Headers:   rec.Headers,
 		})
 		child.offset = offset + 1

--- a/message.go
+++ b/message.go
@@ -19,6 +19,8 @@ const (
 	CompressionZSTD   CompressionCodec = 4
 )
 
+const timestampTypeMask = 0x08
+
 func (cc CompressionCodec) String() string {
 	return []string{
 		"none",

--- a/record_batch.go
+++ b/record_batch.go
@@ -36,6 +36,7 @@ type RecordBatch struct {
 	Codec                 CompressionCodec
 	CompressionLevel      int
 	Control               bool
+	LogAppendTime         bool
 	LastOffsetDelta       int32
 	FirstTimestamp        time.Time
 	MaxTimestamp          time.Time
@@ -120,6 +121,7 @@ func (b *RecordBatch) decode(pd packetDecoder) (err error) {
 	}
 	b.Codec = CompressionCodec(int8(attributes) & compressionCodecMask)
 	b.Control = attributes&controlMask == controlMask
+	b.LogAppendTime = attributes&timestampTypeMask == timestampTypeMask
 
 	if b.LastOffsetDelta, err = pd.getInt32(); err != nil {
 		return err


### PR DESCRIPTION
Sarama does not properly support LogAppend type of timestamps. The change is a replica of https://github.com/dpkp/kafka-python/blob/34fcb11c1cf96d69573274104d3b746ce67a97f4/kafka/record/default_records.py#L204