### PR TITLE
Fix Admin API client to marshal broker resource type correctly

### DIFF
--- a/client_tls_test.go
+++ b/client_tls_test.go
@@ -33,12 +33,12 @@ func TestTLS(t *testing.T) {
 	nva := time.Now().Add(1 * time.Hour)
 
 	caTemplate := &x509.Certificate{
-		Subject:      pkix.Name{CommonName: "ca"},
-		Issuer:       pkix.Name{CommonName: "ca"},
-		SerialNumber: big.NewInt(0),
-		NotAfter:     nva,
-		NotBefore:    nvb,
-		IsCA:         true,
+		Subject:               pkix.Name{CommonName: "ca"},
+		Issuer:                pkix.Name{CommonName: "ca"},
+		SerialNumber:          big.NewInt(0),
+		NotAfter:              nva,
+		NotBefore:             nvb,
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 		KeyUsage:              x509.KeyUsageCertSign,
 	}

--- a/config_resource_type.go
+++ b/config_resource_type.go
@@ -10,6 +10,5 @@ const (
 	AnyResource     ConfigResourceType = 1
 	TopicResource   ConfigResourceType = 2
 	GroupResource   ConfigResourceType = 3
-	ClusterResource ConfigResourceType = 4
-	BrokerResource  ConfigResourceType = 5
+	BrokerResource  ConfigResourceType = 4
 )


### PR DESCRIPTION
When requesting resources from Kafka Admin API `sarama` uses incorrect constant for broker resources. It has to be `4` while `sarama` mistakenly uses `5`. This has been fixed in the `sarama` upstream, and this PR fixes this in our fork of `sarama`.