### PR TITLE
Add detailed per-partition fetch metrics that can be enabled by client

### DIFF
--- a/config.go
+++ b/config.go
@@ -321,6 +321,9 @@ type Config struct {
 			// (no limit). Similar to the JVM's `fetch.message.max.bytes`. The
 			// global `sarama.MaxResponseSize` still applies.
 			Max int32
+			// Called to check if detailed metrics has to be emitted for a
+			// specific topic-partition. By default such metrics are not emitted.
+			DetailedMetricsFunc func(topic string, partition int32) bool
 		}
 		// The maximum amount of time the broker will wait for Consumer.Fetch.Min
 		// bytes to become available before it returns fewer than that anyways. The

--- a/consumer.go
+++ b/consumer.go
@@ -327,6 +327,20 @@ func (child *partitionConsumer) fetchStatsEnabled() bool {
 	return false
 }
 
+func (child *partitionConsumer) maybeIncrementPartitionCounter(name string) {
+	metricRegistry := child.conf.MetricRegistry
+	if child.fetchStatsEnabled() && metricRegistry != nil {
+		getOrRegisterPartitionCounter(name, child.topic, child.partition, metricRegistry).Inc(1)
+	}
+}
+
+func (child *partitionConsumer) maybeUpdatePartitionHistogram(name string, value int64) {
+	metricRegistry := child.conf.MetricRegistry
+	if child.fetchStatsEnabled() && metricRegistry != nil {
+		getOrRegisterPartitionHistogram(name, child.topic, child.partition, metricRegistry).Update(value)
+	}
+}
+
 var errTimedOut = errors.New("timed out feeding messages to the user") // not user-facing
 
 func (child *partitionConsumer) sendError(err error) {
@@ -571,20 +585,6 @@ func (child *partitionConsumer) parseRecords(batch *RecordBatch) ([]*ConsumerMes
 		child.offset++
 	}
 	return messages, nil
-}
-
-func (child *partitionConsumer) maybeIncrementPartitionCounter(name string) {
-	metricRegistry := child.conf.MetricRegistry
-	if child.fetchStatsEnabled() && metricRegistry != nil {
-		getOrRegisterPartitionCounter(name, child.topic, child.partition, metricRegistry).Inc(1)
-	}
-}
-
-func (child *partitionConsumer) maybeUpdatePartitionHistogram(name string, value int64) {
-	metricRegistry := child.conf.MetricRegistry
-	if child.fetchStatsEnabled() && metricRegistry != nil {
-		getOrRegisterPartitionHistogram(name, child.topic, child.partition, metricRegistry).Update(value)
-	}
 }
 
 func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*ConsumerMessage, error) {

--- a/metrics.go
+++ b/metrics.go
@@ -34,10 +34,28 @@ func getMetricNameForTopic(name string, topic string) string {
 	return fmt.Sprintf(name+"-for-topic-%s", strings.Replace(topic, ".", "_", -1))
 }
 
+func getMetricNameForPartition(name string, topic string, partition int32) string {
+	// Convert dot to _ since reporters like Graphite typically use dot to represent hierarchy
+	// cf. KAFKA-1902 and KAFKA-2337
+	return fmt.Sprintf(name+"-for-part-%s-%d", strings.Replace(topic, ".", "_", -1), partition)
+}
+
 func getOrRegisterTopicMeter(name string, topic string, r metrics.Registry) metrics.Meter {
 	return metrics.GetOrRegisterMeter(getMetricNameForTopic(name, topic), r)
 }
 
 func getOrRegisterTopicHistogram(name string, topic string, r metrics.Registry) metrics.Histogram {
 	return getOrRegisterHistogram(getMetricNameForTopic(name, topic), r)
+}
+
+func getOrRegisterPartitionCounter(name string, topic string, partition int32, r metrics.Registry) metrics.Counter {
+	return metrics.GetOrRegisterCounter(getMetricNameForPartition(name, topic, partition), r)
+}
+
+func getOrRegisterPartitionMeter(name string, topic string, partition int32, r metrics.Registry) metrics.Meter {
+	return metrics.GetOrRegisterMeter(getMetricNameForPartition(name, topic, partition), r)
+}
+
+func getOrRegisterPartitionHistogram(name string, topic string, partition int32, r metrics.Registry) metrics.Histogram {
+	return getOrRegisterHistogram(getMetricNameForPartition(name, topic, partition), r)
 }


### PR DESCRIPTION
Add a bunch of partition-level metrics that provide all kinds of details about fetch requests executed for the partition. The metrics are disabled by default and can be enabled for specific topic-partitions by the client. 

I will also add code to `ditto` to keep tracking a couple of "slowest" and "fastest" partitions and to enable/disable detailed fetch metrics for such partitions. It's obvious why we would want this for the slowest partitions. Tracking the fastest partitions  (or actually any couple of partitions that are not the slowest) would be needed just for comparison with the slow ones.

I will also extend `go/kafka/registry.go` to publish new metrics with `gost`.